### PR TITLE
Fix duplicate printing by implementing exclusive control

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Sends print data to the printer.
 - If `data` is a `Uint8Array`, it is treated as raw 1-bit-per-pixel binary data (must be a multiple of 48 bytes).
 - `options.density`: Optional density setting from `1` (lightest) to `7` (darkest). If provided, it automatically sends a density configuration command before printing. It intelligently skips sending the command if the printer is already set to the desired density.
 
+> [!WARNING]
+> The printer does not support concurrent print jobs. If `print()` is called while another print job is in progress, it will immediately throw an error (`Printer is already printing`). You can check the current printing status via `PrinterStatus.isPrinting`.
+
 #### `setDensity(density: number): Promise<void>`
 
 Directly changes the print density. `density` must be a number between `1` and `7`.
@@ -87,13 +90,14 @@ Disconnects the current GATT connection.
 
 ### `PrinterStatus`
 
-- `battery`: number (0-100)
-- `voltage`: number (mV)
-- `isCharging`: boolean
-- `isOutOfPaper`: boolean
-- `isOverheat`: boolean
-- `isLowBattery`: boolean
-- `density`: number (1-7) representing the current hardware density level
+- `isPrinting`: boolean (Indicates whether a print job is currently in progress)
+- `battery`?: number (0-100)
+- `voltage`?: number (mV)
+- `isCharging`?: boolean
+- `isOutOfPaper`?: boolean
+- `isOverheat`?: boolean
+- `isLowBattery`?: boolean
+- `density`?: number (1-7) representing the current hardware density level
 
 ## Acknowledgments
 

--- a/src/printer.test.ts
+++ b/src/printer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { LXD02Printer } from './printer';
+import { LXD02Printer, PrinterStatus } from './printer';
 
 describe('LXD02Printer Authentication & Print Completion', () => {
   it('should complete authentication sequence correctly', async () => {
@@ -214,8 +214,8 @@ describe('LXD02Printer Authentication & Print Completion', () => {
       };
       printer.tx = mockTx;
 
-      const statusChanges: any[] = [];
-      printer.onStatusChange = (s: any) => statusChanges.push(s);
+      const statusChanges: PrinterStatus[] = [];
+      printer.onStatusChange = (s: PrinterStatus) => statusChanges.push(s);
 
       // Start printing
       const printPromise = printer.print(new Uint8Array(48 * 2));
@@ -252,9 +252,9 @@ describe('LXD02Printer Authentication & Print Completion', () => {
     it('should provide a defensive copy to onStatusChange', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const printer = new LXD02Printer() as any;
-      let receivedStatus: any = null;
+      let receivedStatus: PrinterStatus | null = null;
 
-      printer.onStatusChange = (s: any) => {
+      printer.onStatusChange = (s: PrinterStatus) => {
         receivedStatus = s;
         // Attempt to mutate the received status
         s.isPrinting = !s.isPrinting;
@@ -277,7 +277,7 @@ describe('LXD02Printer Authentication & Print Completion', () => {
 
       // Internal status should remain unaffected by the consumer's mutation
       expect(printer.status.battery).toBe(0x50);
-      expect(printer.status.battery).not.toBe(receivedStatus.battery);
+      expect(printer.status.battery).not.toBe(receivedStatus!.battery);
       expect(printer.status.isPrinting).toBe(false);
     });
   });

--- a/src/printer.test.ts
+++ b/src/printer.test.ts
@@ -204,4 +204,81 @@ describe('LXD02Printer Authentication & Print Completion', () => {
       expect(mockTx.writeValueWithoutResponse).not.toHaveBeenCalled();
     });
   });
+
+  describe('Concurrency & Defensive Copy', () => {
+    it('should prevent concurrent printing and toggle isPrinting status', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const printer = new LXD02Printer() as any;
+      const mockTx = {
+        writeValueWithoutResponse: vi.fn().mockResolvedValue(undefined),
+      };
+      printer.tx = mockTx;
+
+      const statusChanges: any[] = [];
+      printer.onStatusChange = (s: any) => statusChanges.push(s);
+
+      // Start printing
+      const printPromise = printer.print(new Uint8Array(48 * 2));
+
+      // 1. Verify isPrinting is true and status notification was called
+      expect(printer.status.isPrinting).toBe(true);
+      expect(statusChanges.length).toBeGreaterThan(0);
+      expect(statusChanges[statusChanges.length - 1].isPrinting).toBe(true);
+
+      // 2. Try to start another print (should fail)
+      await expect(printer.print(new Uint8Array(48))).rejects.toThrow(
+        'Printer is already printing'
+      );
+
+      // 3. Complete the first print (simulate completion notification)
+      const mockValue = new Uint8Array([0x5a, 0x06, 0x00, 0x02]);
+      await printer.handleNotifications({
+        target: {
+          value: {
+            buffer: mockValue.buffer,
+            byteOffset: 0,
+            byteLength: mockValue.length,
+          },
+        },
+      });
+
+      await printPromise;
+
+      // 4. Verify isPrinting is false
+      expect(printer.status.isPrinting).toBe(false);
+      expect(statusChanges[statusChanges.length - 1].isPrinting).toBe(false);
+    });
+
+    it('should provide a defensive copy to onStatusChange', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const printer = new LXD02Printer() as any;
+      let receivedStatus: any = null;
+
+      printer.onStatusChange = (s: any) => {
+        receivedStatus = s;
+        // Attempt to mutate the received status
+        s.isPrinting = !s.isPrinting;
+        s.battery = 999;
+      };
+
+      // Trigger status update (0x5A 0x02 ...)
+      const mockValue = new Uint8Array([
+        0x5a, 0x02, 0x50, 0x00, 0x00, 0x00, 0x00, 0x03, 0x10, 0x00, 0x00, 0x00,
+      ]);
+      await printer.handleNotifications({
+        target: {
+          value: {
+            buffer: mockValue.buffer,
+            byteOffset: 0,
+            byteLength: mockValue.length,
+          },
+        },
+      });
+
+      // Internal status should remain unaffected by the consumer's mutation
+      expect(printer.status.battery).toBe(0x50);
+      expect(printer.status.battery).not.toBe(receivedStatus.battery);
+      expect(printer.status.isPrinting).toBe(false);
+    });
+  });
 });

--- a/src/printer.test.ts
+++ b/src/printer.test.ts
@@ -280,5 +280,40 @@ describe('LXD02Printer Authentication & Print Completion', () => {
       expect(printer.status.battery).not.toBe(receivedStatus!.battery);
       expect(printer.status.isPrinting).toBe(false);
     });
+
+    it('should reset isPrinting even if onStatusChange callback throws', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const printer = new LXD02Printer() as any;
+      printer.tx = {
+        writeValueWithoutResponse: vi.fn().mockResolvedValue(undefined),
+      };
+
+      // Setup a throwing callback
+      printer.onStatusChange = () => {
+        throw new Error('Consumer error');
+      };
+
+      // Start printing
+      const printPromise = printer.print(new Uint8Array(48));
+
+      expect(printer.status.isPrinting).toBe(true);
+
+      // Simulate completion
+      const mockValue = new Uint8Array([0x5a, 0x06, 0x00, 0x01]);
+      await printer.handleNotifications({
+        target: {
+          value: {
+            buffer: mockValue.buffer,
+            byteOffset: 0,
+            byteLength: mockValue.length,
+          },
+        },
+      });
+
+      await printPromise;
+
+      // isPrinting should be false despite the error in notifyStatus
+      expect(printer.status.isPrinting).toBe(false);
+    });
   });
 });

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -6,13 +6,14 @@ const CHR_TX_UUID = 0xffe1; // Write Without Response
 const CHR_RX_UUID = 0xffe2; // Notify
 
 export interface PrinterStatus {
-  battery: number;
-  isOutOfPaper: boolean;
-  isCharging: boolean;
-  isOverheat: boolean;
-  isLowBattery: boolean;
-  density: number;
-  voltage: number;
+  battery?: number;
+  isOutOfPaper?: boolean;
+  isCharging?: boolean;
+  isOverheat?: boolean;
+  isLowBattery?: boolean;
+  density?: number;
+  voltage?: number;
+  isPrinting: boolean;
 }
 
 export class LXD02Printer {
@@ -169,14 +170,28 @@ export class LXD02Printer {
   ): Promise<void> {
     if (!this.tx) throw new Error('Printer not connected');
 
-    if (options?.density !== undefined) {
-      await this.setDensity(options.density);
+    if (this.status?.isPrinting) {
+      throw new Error('Printer is already printing');
     }
 
-    const packets = processImage(data);
-    const packetCount = packets.length;
+    if (!this.status) {
+      this.status = {
+        isPrinting: false,
+      };
+    }
 
-    return new Promise((resolve, reject) => {
+    this.status.isPrinting = true;
+    this.onStatusChange?.(this.status);
+
+    try {
+      if (options?.density !== undefined) {
+        await this.setDensity(options.density);
+      }
+
+      const packets = processImage(data);
+      const packetCount = packets.length;
+
+      await new Promise<void>((resolve, reject) => {
       const timeout = setTimeout(() => {
         this.printResolver = undefined;
         this._onRetransmitRequested = undefined;
@@ -240,15 +255,21 @@ export class LXD02Printer {
         }
       };
 
-      this.sendRaw(startCmd)
-        .then(() => sendPacketsFrom(0))
-        .catch((err) => {
-          clearTimeout(timeout);
-          this.printResolver = undefined;
-          this._onRetransmitRequested = undefined;
-          reject(err);
-        });
-    });
+        this.sendRaw(startCmd)
+          .then(() => sendPacketsFrom(0))
+          .catch((err) => {
+            clearTimeout(timeout);
+            this.printResolver = undefined;
+            this._onRetransmitRequested = undefined;
+            reject(err);
+          });
+      });
+    } finally {
+      if (this.status) {
+        this.status.isPrinting = false;
+        this.onStatusChange?.(this.status);
+      }
+    }
   }
 
   private async handleNotifications(event: Event) {
@@ -332,6 +353,7 @@ export class LXD02Printer {
             isLowBattery: value[6] === 0x01,
             density: value[7]! + 1,
             voltage: (value[8]! << 8) | value[9]!,
+            isPrinting: this.status?.isPrinting ?? false,
           };
           this.status = status;
           this.onStatusChange?.(status);

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -181,7 +181,7 @@ export class LXD02Printer {
     }
 
     this.status.isPrinting = true;
-    this.onStatusChange?.(this.status);
+    this.onStatusChange?.({ ...this.status });
 
     try {
       if (options?.density !== undefined) {
@@ -267,7 +267,7 @@ export class LXD02Printer {
     } finally {
       if (this.status) {
         this.status.isPrinting = false;
-        this.onStatusChange?.(this.status);
+        this.onStatusChange?.({ ...this.status });
       }
     }
   }
@@ -356,7 +356,7 @@ export class LXD02Printer {
             isPrinting: this.status?.isPrinting ?? false,
           };
           this.status = status;
-          this.onStatusChange?.(status);
+          this.onStatusChange?.({ ...status });
         }
         break;
 

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -192,68 +192,68 @@ export class LXD02Printer {
       const packetCount = packets.length;
 
       await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.printResolver = undefined;
-        this._onRetransmitRequested = undefined;
-        reject(new Error('Print timeout'));
-      }, 30000);
-
-      this.printResolver = () => {
-        clearTimeout(timeout);
-        this._onRetransmitRequested = undefined;
-        resolve();
-      };
-
-      const sendPacketsFrom = async (startIndex: number) => {
-        isSending = true;
-        try {
-          let i = startIndex;
-          while (i < packetCount) {
-            // Check if a retransmission was requested via notification during the loop
-            if (this._resendRequestedIndex !== null) {
-              const target = this._resendRequestedIndex;
-              this._resendRequestedIndex = null;
-              if (target < packetCount) {
-                i = target;
-              }
-            }
-
-            await this.sendRaw(packets[i]!);
-            i++;
-          }
-        } catch (err) {
-          clearTimeout(timeout);
+        const timeout = setTimeout(() => {
           this.printResolver = undefined;
           this._onRetransmitRequested = undefined;
-          reject(err);
-        } finally {
-          isSending = false;
-        }
-      };
+          reject(new Error('Print timeout'));
+        }, 30000);
 
-      // 1. Send Print Start Command
-      // Length = (Total lines rounded up / 2) + 1 (which is packets.length)
-      const startCmd = new Uint8Array([
-        0x5a,
-        0x04,
-        (packetCount >> 8) & 0xff,
-        packetCount & 0xff,
-        0x00,
-        0x00,
-      ]);
+        this.printResolver = () => {
+          clearTimeout(timeout);
+          this._onRetransmitRequested = undefined;
+          resolve();
+        };
 
-      let isSending = false;
+        const sendPacketsFrom = async (startIndex: number) => {
+          isSending = true;
+          try {
+            let i = startIndex;
+            while (i < packetCount) {
+              // Check if a retransmission was requested via notification during the loop
+              if (this._resendRequestedIndex !== null) {
+                const target = this._resendRequestedIndex;
+                this._resendRequestedIndex = null;
+                if (target < packetCount) {
+                  i = target;
+                }
+              }
 
-      this._onRetransmitRequested = async (targetIndex: number) => {
-        if (isSending) {
-          // If a loop is already running, just update the index so the loop will jump backwards.
-          this._resendRequestedIndex = targetIndex;
-        } else {
-          // If the loop finished but we haven't received completion (0x06) yet, start a new loop.
-          this._resendRequestedIndex = null;
-          await sendPacketsFrom(targetIndex);
-        }
-      };
+              await this.sendRaw(packets[i]!);
+              i++;
+            }
+          } catch (err) {
+            clearTimeout(timeout);
+            this.printResolver = undefined;
+            this._onRetransmitRequested = undefined;
+            reject(err);
+          } finally {
+            isSending = false;
+          }
+        };
+
+        // 1. Send Print Start Command
+        // Length = (Total lines rounded up / 2) + 1 (which is packets.length)
+        const startCmd = new Uint8Array([
+          0x5a,
+          0x04,
+          (packetCount >> 8) & 0xff,
+          packetCount & 0xff,
+          0x00,
+          0x00,
+        ]);
+
+        let isSending = false;
+
+        this._onRetransmitRequested = async (targetIndex: number) => {
+          if (isSending) {
+            // If a loop is already running, just update the index so the loop will jump backwards.
+            this._resendRequestedIndex = targetIndex;
+          } else {
+            // If the loop finished but we haven't received completion (0x06) yet, start a new loop.
+            this._resendRequestedIndex = null;
+            await sendPacketsFrom(targetIndex);
+          }
+        };
 
         this.sendRaw(startCmd)
           .then(() => sendPacketsFrom(0))

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -181,9 +181,8 @@ export class LXD02Printer {
     }
 
     this.status.isPrinting = true;
-    this.onStatusChange?.({ ...this.status });
-
     try {
+      this.notifyStatus();
       if (options?.density !== undefined) {
         await this.setDensity(options.density);
       }
@@ -267,7 +266,7 @@ export class LXD02Printer {
     } finally {
       if (this.status) {
         this.status.isPrinting = false;
-        this.onStatusChange?.({ ...this.status });
+        this.notifyStatus();
       }
     }
   }
@@ -356,7 +355,7 @@ export class LXD02Printer {
             isPrinting: this.status?.isPrinting ?? false,
           };
           this.status = status;
-          this.onStatusChange?.({ ...status });
+          this.notifyStatus();
         }
         break;
 
@@ -402,6 +401,16 @@ export class LXD02Printer {
     }
     if (this.device?.gatt?.connected) {
       this.device.gatt.disconnect();
+    }
+  }
+
+  private notifyStatus(): void {
+    if (this.onStatusChange && this.status) {
+      try {
+        this.onStatusChange({ ...this.status });
+      } catch (err) {
+        console.error('Unhandled error in onStatusChange callback:', err);
+      }
     }
   }
 }


### PR DESCRIPTION
## Overview
This PR implements exclusive control for the printing process to prevent duplicate output caused by simultaneous print requests. It also strengthens state management by introducing defensive copying of the status object and protecting internal state transitions from external callback errors.

## Changes
- **Exclusive Control:** Added a check in the `print()` method to prevent overlapping print jobs. If a print request is made while another is in progress, an error is now thrown.
- **Error Resilience:** Wrapped status notifications (`onStatusChange`) in a protected `notifyStatus()` method. This ensures that even if a consumer's callback throws an error, the library can still complete its internal state cleanup (e.g., resetting `isPrinting` to `false`).
- **Defensive Copying:** Modified status notifications to pass a copy of the status object (`{ ...status }`). This prevents external consumers from inadvertently mutating the printer's internal state.
- **PrinterStatus Update:**
    - Added `isPrinting` boolean to track the current printing state.
    - Changed other status properties to be optional to avoid using inaccurate dummy values during initialization.
- **Tests:**
    - Added unit tests to verify the exclusive control behavior and state transitions.
    - Added a unit test to verify that `onStatusChange` provides a defensive copy.
    - Added a unit test to verify that internal state cleanup succeeds even if the `onStatusChange` callback throws an error.
- **Documentation:** Updated `README.md` with information about concurrent printing and the updated `PrinterStatus` interface.

## Related Issue
- Closes #6