### PR TITLE
feat: add connection status monitoring and disconnection notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ import { LXD02Printer } from 'lx-printer/lx-d02';
 const printer = new LXD02Printer({
   onStatusChange: (status) => {
     if (status.isConnected) {
-      console.log(`Battery: ${status.battery}%`);
+      if (status.battery !== undefined) {
+        console.log(`Battery: ${status.battery}%`);
+      } else {
+        console.log('Battery: checking...');
+      }
     } else {
       console.log('Printer disconnected');
     }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ import { LXD02Printer } from 'lx-printer/lx-d02';
 
 const printer = new LXD02Printer({
   onStatusChange: (status) => {
-    console.log(`Battery: ${status.battery}%`);
+    if (status.isConnected) {
+      console.log(`Battery: ${status.battery}%`);
+    } else {
+      console.log('Printer disconnected');
+    }
     if (status.isOutOfPaper) {
       console.error('Out of paper!');
     }
@@ -90,6 +94,7 @@ Disconnects the current GATT connection.
 
 ### `PrinterStatus`
 
+- `isConnected`: boolean (Indicates whether the printer is currently connected via Bluetooth)
 - `isPrinting`: boolean (Indicates whether a print job is currently in progress)
 - `battery`?: number (0-100)
 - `voltage`?: number (mV)

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -71,9 +71,6 @@ btnConnect.addEventListener('click', async () => {
   if (isConnected && printer) {
     log('Disconnecting...');
     printer.disconnect();
-    isConnected = false;
-    updateUI();
-    log('Disconnected.', 'info');
     return;
   }
 
@@ -85,8 +82,23 @@ btnConnect.addEventListener('click', async () => {
 
     printer = new LXD02Printer({
       onStatusChange: (status) => {
-        statBattery.textContent = `${status.battery}%`;
-        statVoltage.textContent = `${status.voltage} mV`;
+        if (isConnected !== status.isConnected) {
+          isConnected = status.isConnected;
+          updateUI();
+          if (!isConnected) {
+            log('Printer disconnected.', 'error');
+          }
+        }
+
+        if (!status.isConnected) return;
+
+        if (status.battery !== undefined) {
+          statBattery.textContent = `${status.battery}%`;
+        }
+        if (status.voltage !== undefined) {
+          statVoltage.textContent = `${status.voltage} mV`;
+        }
+
         statCharging.textContent = status.isCharging ? 'Yes' : 'No';
         statCharging.style.color = status.isCharging
           ? 'var(--success)'
@@ -101,13 +113,13 @@ btnConnect.addEventListener('click', async () => {
         statFlags.style.color =
           flags.length > 0 ? 'var(--error)' : 'var(--success)';
 
-        statDensity.textContent = status.density.toString();
+        if (status.density !== undefined) {
+          statDensity.textContent = status.density.toString();
+        }
       },
     });
 
     await printer.connect();
-    isConnected = true;
-    updateUI();
     log('Printer connected and authenticated!', 'success');
   } catch (err) {
     handleError(err, 'Connection failed');

--- a/src/printer.test.ts
+++ b/src/printer.test.ts
@@ -347,10 +347,20 @@ describe('LXD02Printer Authentication & Print Completion', () => {
     it('should register and unregister gattserverdisconnected listener', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const printer = new LXD02Printer() as any;
+      const mockServer = {
+        getPrimaryService: vi.fn().mockResolvedValue({
+          getCharacteristic: vi.fn().mockResolvedValue({
+            startNotifications: vi.fn().mockResolvedValue(undefined),
+            stopNotifications: vi.fn().mockResolvedValue(undefined),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+          }),
+        }),
+      };
       const mockDevice = {
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
-        gatt: { connect: vi.fn().mockResolvedValue({}) },
+        gatt: { connect: vi.fn().mockResolvedValue(mockServer) },
       };
 
       // Mock navigator.bluetooth
@@ -361,15 +371,10 @@ describe('LXD02Printer Authentication & Print Completion', () => {
         requestDevice: vi.fn().mockResolvedValue(mockDevice as any),
       };
 
-      // Mock other methods to prevent full connection flow
-      printer.getPrimaryService = vi.fn().mockResolvedValue({});
+      // Mock authenticate to prevent full connection flow
       printer.authenticate = vi.fn().mockResolvedValue(undefined);
 
-      try {
-        await printer.connect();
-      } catch {
-        // Expected to fail in getPrimaryService mock but we care about listener
-      }
+      await printer.connect();
 
       expect(mockDevice.addEventListener).toHaveBeenCalledWith(
         'gattserverdisconnected',
@@ -390,6 +395,21 @@ describe('LXD02Printer Authentication & Print Completion', () => {
       // Restore
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (global.navigator as any).bluetooth = originalBluetooth;
+    });
+
+    it('should reject pending operations on disconnect', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const printer = new LXD02Printer() as any;
+      printer.tx = {
+        writeValueWithoutResponse: vi.fn().mockResolvedValue(undefined),
+      };
+      printer.status = { isConnected: true, isPrinting: false };
+
+      const printPromise = printer.print(new Uint8Array(48));
+
+      printer.handleDisconnect();
+
+      await expect(printPromise).rejects.toThrow('Printer disconnected');
     });
   });
 });

--- a/src/printer.test.ts
+++ b/src/printer.test.ts
@@ -123,6 +123,7 @@ describe('LXD02Printer Authentication & Print Completion', () => {
 
       // Initialize status to verify cache update
       printer.status = {
+        isConnected: true,
         battery: 100,
         isOutOfPaper: false,
         isCharging: false,
@@ -130,6 +131,7 @@ describe('LXD02Printer Authentication & Print Completion', () => {
         isLowBattery: false,
         density: 4,
         voltage: 4000,
+        isPrinting: false,
       };
 
       const densityPromise = printer.setDensity(7);
@@ -198,7 +200,7 @@ describe('LXD02Printer Authentication & Print Completion', () => {
       const printer = new LXD02Printer() as any;
       const mockTx = { writeValueWithoutResponse: vi.fn() };
       printer.tx = mockTx;
-      printer.status = { density: 4 };
+      printer.status = { isConnected: true, density: 4, isPrinting: false };
 
       await printer.setDensity(4);
       expect(mockTx.writeValueWithoutResponse).not.toHaveBeenCalled();
@@ -314,6 +316,80 @@ describe('LXD02Printer Authentication & Print Completion', () => {
 
       // isPrinting should be false despite the error in notifyStatus
       expect(printer.status.isPrinting).toBe(false);
+    });
+  });
+
+  describe('Disconnection', () => {
+    it('should update isConnected to false on handleDisconnect', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const printer = new LXD02Printer() as any;
+      let lastStatus: PrinterStatus | null = null;
+      printer.onStatusChange = (s: PrinterStatus) => {
+        lastStatus = s;
+      };
+
+      printer.status = { isConnected: true, isPrinting: true };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      printer.tx = {} as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      printer.rx = {} as any;
+
+      printer.handleDisconnect();
+
+      expect(printer.status.isConnected).toBe(false);
+      expect(printer.status.isPrinting).toBe(false);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((lastStatus as any)?.isConnected).toBe(false);
+      expect(printer.tx).toBeNull();
+      expect(printer.rx).toBeNull();
+    });
+
+    it('should register and unregister gattserverdisconnected listener', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const printer = new LXD02Printer() as any;
+      const mockDevice = {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        gatt: { connect: vi.fn().mockResolvedValue({}) },
+      };
+
+      // Mock navigator.bluetooth
+      const originalBluetooth = global.navigator.bluetooth;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global.navigator as any).bluetooth = {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        requestDevice: vi.fn().mockResolvedValue(mockDevice as any),
+      };
+
+      // Mock other methods to prevent full connection flow
+      printer.getPrimaryService = vi.fn().mockResolvedValue({});
+      printer.authenticate = vi.fn().mockResolvedValue(undefined);
+
+      try {
+        await printer.connect();
+      } catch {
+        // Expected to fail in getPrimaryService mock but we care about listener
+      }
+
+      expect(mockDevice.addEventListener).toHaveBeenCalledWith(
+        'gattserverdisconnected',
+        expect.any(Function)
+      );
+
+      const listener = mockDevice.addEventListener.mock.calls[0][1];
+      printer.boundHandleDisconnect = listener;
+      printer.device = mockDevice;
+
+      printer.disconnect();
+
+      expect(mockDevice.removeEventListener).toHaveBeenCalledWith(
+        'gattserverdisconnected',
+        listener
+      );
+
+      // Restore
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (global.navigator as any).bluetooth = originalBluetooth;
     });
   });
 });

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -24,9 +24,10 @@ export class LXD02Printer {
   private status: PrinterStatus | null = null;
 
   private onStatusChange?: (status: PrinterStatus) => void;
-  private authResolver?: (result: boolean) => void;
+  private authResolver?: (result: boolean, error?: Error) => void;
   private printResolver?: () => void;
-  private densityResolver?: (success: boolean) => void;
+  private printRejecter?: (error: Error) => void;
+  private densityResolver?: (success: boolean, error?: Error) => void;
   private _onRetransmitRequested?: (index: number) => Promise<void> | void;
   private _resendRequestedIndex: number | null = null;
   private boundHandleNotifications: ((event: Event) => void) | null = null;
@@ -48,6 +49,14 @@ export class LXD02Printer {
         filters: [{ namePrefix: 'LX' }],
         optionalServices: [SERVICE_UUID],
       });
+
+      // Remove existing listener if any (e.g. from a previous failed/incomplete connection)
+      if (this.boundHandleDisconnect) {
+        this.device.removeEventListener(
+          'gattserverdisconnected',
+          this.boundHandleDisconnect
+        );
+      }
 
       this.boundHandleDisconnect = () => this.handleDisconnect();
       this.device.addEventListener(
@@ -84,6 +93,14 @@ export class LXD02Printer {
       };
       this.notifyStatus();
     } catch (error) {
+      if (this.device && this.boundHandleDisconnect) {
+        this.device.removeEventListener(
+          'gattserverdisconnected',
+          this.boundHandleDisconnect
+        );
+        this.boundHandleDisconnect = null;
+      }
+
       if (this.rx && this.boundHandleNotifications) {
         this.rx.removeEventListener(
           'characteristicvaluechanged',
@@ -118,10 +135,11 @@ export class LXD02Printer {
         reject(new Error('Authentication timeout'));
       }, 10000);
 
-      this.authResolver = (success) => {
+      this.authResolver = (success, err) => {
         clearTimeout(timeout);
+        this.authResolver = undefined;
         if (success) resolve();
-        else reject(new Error('Authentication failed'));
+        else reject(err || new Error('Authentication failed'));
       };
 
       // Stage 0: Initiate Authentication
@@ -158,7 +176,7 @@ export class LXD02Printer {
         reject(new Error('Density setting timeout'));
       }, 5000);
 
-      this.densityResolver = (success) => {
+      this.densityResolver = (success, err) => {
         clearTimeout(timeout);
         this.densityResolver = undefined;
         if (success) {
@@ -167,7 +185,7 @@ export class LXD02Printer {
           }
           resolve();
         } else {
-          reject(new Error('Failed to set density'));
+          reject(err || new Error('Failed to set density'));
         }
       };
 
@@ -216,8 +234,18 @@ export class LXD02Printer {
 
         this.printResolver = () => {
           clearTimeout(timeout);
+          this.printResolver = undefined;
+          this.printRejecter = undefined;
           this._onRetransmitRequested = undefined;
           resolve();
+        };
+
+        this.printRejecter = (err) => {
+          clearTimeout(timeout);
+          this.printResolver = undefined;
+          this.printRejecter = undefined;
+          this._onRetransmitRequested = undefined;
+          reject(err);
         };
 
         const sendPacketsFrom = async (startIndex: number) => {
@@ -276,6 +304,7 @@ export class LXD02Printer {
           .catch((err) => {
             clearTimeout(timeout);
             this.printResolver = undefined;
+            this.printRejecter = undefined;
             this._onRetransmitRequested = undefined;
             reject(err);
           });
@@ -417,6 +446,15 @@ export class LXD02Printer {
       this.boundHandleDisconnect = null;
     }
 
+    if (this.device?.gatt?.connected) {
+      this.device.gatt.disconnect();
+    }
+
+    this.handleDisconnect();
+  }
+
+  private handleDisconnect() {
+    // 1. Cleanup notification listeners before clearing references
     if (this.rx && this.boundHandleNotifications) {
       this.rx.removeEventListener(
         'characteristicvaluechanged',
@@ -426,19 +464,26 @@ export class LXD02Printer {
       this.boundHandleNotifications = null;
     }
 
-    if (this.device?.gatt?.connected) {
-      this.device.gatt.disconnect();
+    // 2. Reject in-flight operations
+    const disconnectError = new Error('Printer disconnected');
+    if (this.authResolver) {
+      this.authResolver(false, disconnectError);
+    }
+    if (this.densityResolver) {
+      this.densityResolver(false, disconnectError);
+    }
+    if (this.printRejecter) {
+      this.printRejecter(disconnectError);
     }
 
-    this.handleDisconnect();
-  }
-
-  private handleDisconnect() {
+    // 3. Update status
     if (this.status) {
       this.status.isConnected = false;
       this.status.isPrinting = false;
       this.notifyStatus();
     }
+
+    // 4. Clear references
     this.tx = null;
     this.rx = null;
   }

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -6,6 +6,7 @@ const CHR_TX_UUID = 0xffe1; // Write Without Response
 const CHR_RX_UUID = 0xffe2; // Notify
 
 export interface PrinterStatus {
+  isConnected: boolean;
   battery?: number;
   isOutOfPaper?: boolean;
   isCharging?: boolean;
@@ -29,6 +30,7 @@ export class LXD02Printer {
   private _onRetransmitRequested?: (index: number) => Promise<void> | void;
   private _resendRequestedIndex: number | null = null;
   private boundHandleNotifications: ((event: Event) => void) | null = null;
+  private boundHandleDisconnect: (() => void) | null = null;
 
   constructor(options?: { onStatusChange?: (status: PrinterStatus) => void }) {
     this.onStatusChange = options?.onStatusChange;
@@ -46,6 +48,12 @@ export class LXD02Printer {
         filters: [{ namePrefix: 'LX' }],
         optionalServices: [SERVICE_UUID],
       });
+
+      this.boundHandleDisconnect = () => this.handleDisconnect();
+      this.device.addEventListener(
+        'gattserverdisconnected',
+        this.boundHandleDisconnect
+      );
 
       const server = await this.device.gatt?.connect();
       if (!server) throw new Error('Failed to connect to GATT server');
@@ -68,6 +76,13 @@ export class LXD02Printer {
 
       // Start Authentication
       await this.authenticate();
+
+      this.status = {
+        ...(this.status ?? {}),
+        isConnected: true,
+        isPrinting: false,
+      };
+      this.notifyStatus();
     } catch (error) {
       if (this.rx && this.boundHandleNotifications) {
         this.rx.removeEventListener(
@@ -176,11 +191,13 @@ export class LXD02Printer {
 
     if (!this.status) {
       this.status = {
+        isConnected: true,
         isPrinting: false,
       };
     }
 
-    this.status.isPrinting = true;
+    const currentStatus = this.status;
+    currentStatus.isPrinting = true;
     try {
       this.notifyStatus();
       if (options?.density !== undefined) {
@@ -345,6 +362,7 @@ export class LXD02Printer {
       case 0x02: // Status
         if (value.length >= 12) {
           const status: PrinterStatus = {
+            isConnected: true,
             battery: value[2]!,
             isOutOfPaper: value[3] === 0x01,
             isCharging: value[4] === 0x01,
@@ -391,6 +409,14 @@ export class LXD02Printer {
   }
 
   disconnect(): void {
+    if (this.device && this.boundHandleDisconnect) {
+      this.device.removeEventListener(
+        'gattserverdisconnected',
+        this.boundHandleDisconnect
+      );
+      this.boundHandleDisconnect = null;
+    }
+
     if (this.rx && this.boundHandleNotifications) {
       this.rx.removeEventListener(
         'characteristicvaluechanged',
@@ -399,9 +425,22 @@ export class LXD02Printer {
       this.rx.stopNotifications().catch(() => {});
       this.boundHandleNotifications = null;
     }
+
     if (this.device?.gatt?.connected) {
       this.device.gatt.disconnect();
     }
+
+    this.handleDisconnect();
+  }
+
+  private handleDisconnect() {
+    if (this.status) {
+      this.status.isConnected = false;
+      this.status.isPrinting = false;
+      this.notifyStatus();
+    }
+    this.tx = null;
+    this.rx = null;
   }
 
   private notifyStatus(): void {


### PR DESCRIPTION
## Summary
This PR implements real-time monitoring of the printer's connection status.
It allows library consumers to detect when the printer has been disconnected (e.g., due to power loss or going out of range) via the existing `onStatusChange` callback.

## Key Changes
- **Library Core (`src/printer.ts`)**:
    - Added `isConnected` field to `PrinterStatus` interface.
    - Implemented a listener for the Web Bluetooth `gattserverdisconnected` event.
    - Added logic to automatically update and notify status when a disconnection occurs.
- **Demo Application (`demo/main.ts`)**:
    - Updated UI logic to use `status.isConnected` for real-time connection status display.
    - Improved robustness of status display when properties are undefined.
- **Documentation (`README.md`)**:
    - Updated `PrinterStatus` documentation and added a usage example for disconnection detection.
- **Tests (`src/printer.test.ts`)**:
    - Added unit tests for disconnection event handling and state transitions.

## Verification
- Verified that `npm run lint` and `npx tsc --noEmit` pass.
- Verified that all unit tests pass (`npm test`).